### PR TITLE
Adjust charge level regex to account for new format of some pmset lines

### DIFF
--- a/src/screen_on_time.py
+++ b/src/screen_on_time.py
@@ -20,7 +20,7 @@ def main():
     start_index = start_charge = start_timestamp = start_display_state = None
     charge_regex = re.compile(
         TIMESTAMP_REGEX
-        + r"\s+\w+\s+.*Using (?P<type>AC|Batt|BATT) \(Charge:\s*(?P<charge>\d+)%*\)"
+        + r"\s+\w+\s+.*Using (?P<type>AC|Batt|BATT)\s*\(Charge:\s*(?P<charge>\d+)%*\)"
     )
     display_regex = re.compile(
         TIMESTAMP_REGEX + r"\s+\w+\s+Display is turned (?P<state>\w+)"


### PR DESCRIPTION
Some lines are missing the space between the connection state and
the charge parenthesis, e.g.:

```
2023-06-22 12:35:07 +0200 Assertions          	Summary- [System: PrevIdle DeclUser NetAcc kCPU kDisp] Using AC(Charge: 25)
```
