### PR TITLE
Prevent division by zero for battery consumption rate

### DIFF
--- a/src/screen_on_time.py
+++ b/src/screen_on_time.py
@@ -136,12 +136,12 @@ def main():
     print("\nStatistics:")
     print(
         "{:.2f}%/h battery loss during usage".format(
-            total_consumption_with_display_on / (total_time_with_display_on / 3600)
+            total_consumption_with_display_on / (total_time_with_display_on / 3600) if total_time_with_display_on else 0
         )
     )
     print(
         "{:.2f}%/h battery loss during sleep".format(
-            total_consumption_with_display_off / (total_time_with_display_off / 3600)
+            total_consumption_with_display_off / (total_time_with_display_off / 3600) if total_consumption_with_display_off else 0
         )
     )
 


### PR DESCRIPTION
Apple silicon is very efficient and the charge percentage has no
decimal precision, so it is common to have 0%/h rate after
disconecting the power cord.

For example, at the time of commiting, my 15" air hasn't consumed
a single 1% in almost half an hour:

```

2023-06-22 13:30:51 to 2023-06-22 14:00:22: Used   0% of battery during   0h 29min of usage

Summary:
Unplugged from AC on 2023-06-22 13:30:51 with 84% battery
Used   0% of battery during   0h 29min of active usage
Used   0% of battery during   0h  0min of sleep

Statistics:
0.00%/h battery loss during usage
Traceback (most recent call last):
  File "/Users/sam/Code/screen-on-time/./src/screen_on_time.py", line 206, in <module>
    main()
  File "/Users/sam/Code/screen-on-time/./src/screen_on_time.py", line 156, in main
    total_consumption_with_display_off / (total_time_with_display_off / 3600)
ZeroDivisionError: float division by zero
```

After this fix:

```

2023-06-22 13:30:51 to 2023-06-22 14:01:16: Used   0% of battery during   0h 30min of usage

Summary:
Unplugged from AC on 2023-06-22 13:30:51 with 84% battery
Used   0% of battery during   0h 30min of active usage
Used   0% of battery during   0h  0min of sleep

Statistics:
0.00%/h battery loss during usage
0.00%/h battery loss during sleep
```
